### PR TITLE
Remove unsupported field

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,6 @@ updates:
     schedule:
       interval: 'weekly'
       time: '10:00'
-    versioning-strategy: 'increase'
     open-pull-requests-limit: 10
     
   - package-ecosystem: 'npm'


### PR DESCRIPTION
Removing the `versioning-strategy` from the `github-actions` section.